### PR TITLE
Update BibTeXFormatter.ts

### DIFF
--- a/src/BibTeXFormatter.ts
+++ b/src/BibTeXFormatter.ts
@@ -162,7 +162,7 @@ export class BibTeXFormatter {
 		let authors = this.getValueOfNextSymbol(document, document.lineAt(linenum).range.start, "author");
 		return authors
 			.toLowerCase()
-			.split("\band\b")
+			.split(/\band\b/)
 			.map(a => this.capitalizeAuthors(a.trim()));
 	}
 

--- a/src/BibTeXFormatter.ts
+++ b/src/BibTeXFormatter.ts
@@ -162,7 +162,7 @@ export class BibTeXFormatter {
 		let authors = this.getValueOfNextSymbol(document, document.lineAt(linenum).range.start, "author");
 		return authors
 			.toLowerCase()
-			.split("\Wand\W")
+			.split("\band\b")
 			.map(a => this.capitalizeAuthors(a.trim()));
 	}
 


### PR DESCRIPTION
## Scope

Implemented:
 - Changed regexp for authors seperator from `\Wand\W` to `\band\b`


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Review requested on `latest` commit.
